### PR TITLE
correct-charts-dialect

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -38,3 +38,4 @@ Sa
 Holten
 unscale
 unscaled
+ls

--- a/configuration/README.md
+++ b/configuration/README.md
@@ -4,7 +4,7 @@ The Property widget displays `entity tags` and `properties` in tabular format.
 
 The list of selected properties is identified with the `type` field, whereas `$entity_tags` is reserved for `entity tags`.
 
-```css
+```ls
 [widget]
   type = property
   title = Entity Tags
@@ -30,7 +30,7 @@ The list of selected properties is identified with the `type` field, whereas `$e
 
 When the list of columns is not known in advance or there are too many, use `expand-tags` to display all tags returned for the given type.
 
-```css
+```ls
 [widget]
 type = property
 title = Entity Tags

--- a/configuration/aggregators.md
+++ b/configuration/aggregators.md
@@ -81,7 +81,7 @@ Calculation: `Weight = (sample.time - first.time)/(last.time - first.time + 1)`
 > * `startime = 2015-09-14 10:00:00` includes data points occurring exactly at `10:00:00` and later.<br>
 > * `Endtime = 2015-09-14 11:00:00` includes data points occurring up to `10:59:59`, excluding points that occurred at `11:00:00` and later.
 
-```css
+```ls
 count                  = 11
 first                  = 11
 last                   = 13

--- a/configuration/aggregators.md
+++ b/configuration/aggregators.md
@@ -81,7 +81,7 @@ Calculation: `Weight = (sample.time - first.time)/(last.time - first.time + 1)`
 > * `startime = 2015-09-14 10:00:00` includes data points occurring exactly at `10:00:00` and later.<br>
 > * `Endtime = 2015-09-14 11:00:00` includes data points occurring up to `10:59:59`, excluding points that occurred at `11:00:00` and later.
 
-```ls
+```txt
 count                  = 11
 first                  = 11
 last                   = 13

--- a/configuration/baselines.md
+++ b/configuration/baselines.md
@@ -2,7 +2,7 @@
 
 Multiple timespans of the same series can be combined in one widget using the `time-offset` setting to compare for example, current data versus data from some time ago.
 
-```css
+```ls
 [series]
   label = today
 [series]
@@ -23,7 +23,7 @@ See [ATSD Use Cases](https://axibase.com/use-cases/) for other uses for the `tim
 
 1. [California Water Portals](https://axibase.com/use-cases/chart-of-the-day/water-portal/)
 
-    ```css
+    ```ls
     list ofs = 0, 1, 2, 3, 4, 5, 10
     for offs in ofs
     [series]
@@ -38,7 +38,7 @@ See [ATSD Use Cases](https://axibase.com/use-cases/) for other uses for the `tim
 
 1. [Tax Day 2018: Americans Reverse the Late-Filing Trend](https://axibase.com/use-cases/research/irs-tax-filings/)
 
-    ```css
+    ```ls
     [widget]
      var offsets = range(2,6)
      for ofs in offsets

--- a/configuration/computed-metrics.md
+++ b/configuration/computed-metrics.md
@@ -10,7 +10,7 @@ Use the `replace-value` setting to replace the input value when no references to
 
 In the example above, the second chart uses `log10` values to compare samples of different magnitude.
 
-```css
+```ls
 replace-value = Math.log10(value)
 ```
 
@@ -20,7 +20,7 @@ replace-value = Math.log10(value)
 
 In this example, the underlying series are hidden and another visible series is created which displays the ratio of two hidden series multiplied to a percentage value. To reference other series, such underlying series must be assigned unique identifiers with the alias setting.
 
-```css
+```ls
 [series]
   metric = nmon.logical_partition.physicalcpu
   alias = pcpu

--- a/configuration/display-filters.md
+++ b/configuration/display-filters.md
@@ -8,7 +8,7 @@ These expressions can compare `last value` or statistics with a pre-defined thre
 
 ### Display Top Three Results
 
-```css
+```ls
 [series]
 /* show top-3 series by last value */
 display = value >= top(3)
@@ -20,7 +20,7 @@ display = value >= top(3)
 
 ### Single Day Maximum Exceeds Five
 
-```css
+```ls
 [widget]
 enabled = max('1 day') > 5
 ```
@@ -33,7 +33,7 @@ enabled = max('1 day') > 5
 
 Exclude series with `!=` negation syntax.
 
-```css
+```ls
 [series]
 display = tags.mount_point != '/'
 
@@ -52,7 +52,7 @@ tags.mount_point.indexOf('/m') < 0
 
 Calendar display filter.
 
-```css
+```ls
 [widget]
 display = tags.level == 'DEBUG'
 ```

--- a/configuration/drop-down-lists.md
+++ b/configuration/drop-down-lists.md
@@ -26,25 +26,25 @@ Each option has `value` and `text` attributes. If `text` is specified, the text 
 
 Comma-separated list:
 
-```css
+```ls
 options = opt1, opt2, opt3
 ```
 
 Placeholder to `list` of `var` array:
 
-```css
+```ls
 options = @{taglist}
 ```
 
 If the list or array contains elements with a comma, use the `escape()` method to backslash commas:
 
-```css
+```ls
 options = @{taglist.escape()}
 ```
 
 `[option]` fields:
 
-```css
+```ls
 [option]
   text = opt1
 [option]
@@ -58,7 +58,7 @@ options = @{taglist.escape()}
 
 ### Change Widget Type
 
-```css
+```ls
 [widget]
   type = bar
 
@@ -79,7 +79,7 @@ the list of displayed options is specified in options field */
 
 ### Change Property Type
 
-```css
+```ls
 [dropdown]
   on-change = widget.post.queries[0].type = this.value; widget.reload();
   change-field = property.type
@@ -95,7 +95,7 @@ the list of displayed options is specified in options field */
 
 ### Change `Metric`, `Entity`, or Both
 
-```css
+```ls
 [dropdown]
   change-field = series.metric
   options = cpu_user, cpu_system, cpu_busy
@@ -110,7 +110,7 @@ the list of displayed options is specified in options field */
 
 ### Replace Series
 
-```css
+```ls
 [dropdown]
   options = nurswgvml007, nurswgvml006, nurswgvml010
   on-change = replaceEntityInSeriesCollection(cpu_series, this.value); cpu_widget.replaceSeries(cpu_series);  replaceEntityInSeriesCollection(disk_series, this.value); disk_widget.replaceSeries(disk_series);

--- a/configuration/inheritance.md
+++ b/configuration/inheritance.md
@@ -4,7 +4,7 @@ Specify shared settings at the `[configuration]` level, or group-specific settin
 
 If all widgets in a portal are created for the same server, set the `entity` setting at the `[configuration]` level. All included widgets share the same `entity` setting. This makes syntax more compact and easy to replace shared settings.
 
-```css
+```ls
 [widget]
   type = chart
   title = 'metric'
@@ -33,13 +33,13 @@ In this example, the same metric is inherited by all series in the widget becaus
 
 To override or reset an inherited setting to the default value, specify the name of the setting as an empty string:
 
-```css
+```ls
 statistic =
 ```
 
 If a setting needs to be set to whitespace or empty string, specify the value of the setting in double quotes:
 
-```css
+```ls
 statistic = ""
 ```
 

--- a/configuration/meta-data.md
+++ b/configuration/meta-data.md
@@ -28,7 +28,7 @@ Use these fields in widget settings for several common use cases:
 
 ## Syntax
 
-```css
+```ls
 [widget]
   type = chart
   label-format = meta.entity.tags.app - statistic
@@ -67,7 +67,7 @@ Access these functions in the following settings:
 * `link-alert-expression` (Chart)
 * `node-alert-expression` (Chart)
 
-```css
+```ls
 [group]
 
 /* columns which are higher than threshold,

--- a/configuration/summary-portals.md
+++ b/configuration/summary-portals.md
@@ -6,7 +6,7 @@ Use a combination of inheritance and control structures, in particular `for` and
 
 [![](./images/button.png)](https://apps.axibase.com/chartlab/3230deb6/1)
 
-```css
+```ls
 list servers = awsswgvml001, nurswgvml003, nurswgvml009
 [widget]
     type = chart
@@ -31,7 +31,7 @@ As an alternative to specifying list elements manually, lists can be retrieved f
 
 Return the list of agents collecting data. If the group contains hosts with agents, they are traversed to the agent level to return the list of agents. For example, if the groups contains hosts `ABC` (ITM Linux) and `CDE.axibase.com` (SCOM), the method returns agent identifiers: `abc:LX` and `Microsoft.Window.Computer:CDE.axibase.com`.
 
-```css
+```ls
 list resources = ${getResourcesForGroup("linux")?join(",")}
 list resources = ${getResourcesForGroup("windows_server_2008")?join(",")}
 ```
@@ -40,13 +40,13 @@ list resources = ${getResourcesForGroup("windows_server_2008")?join(",")}
 
 Return list of hosts. If the group contains agents, they are traversed up the tree to return hosts.
 
-```css
+```ls
 list hosts = ${getHostsForGroup("scom-itm_group", "LZ")?join(",")}
 ```
 
 If the group contains agents with different product codes, address specifics using a `if` or `endif` condition based on the agent name, or the method can executed multiple times by filtering the group by different product codes.
 
-```css
+```ls
 [widget]
   type = chart
   title = Memory Usage for Linux and Windows Servers

--- a/syntax/alert-expression.md
+++ b/syntax/alert-expression.md
@@ -5,7 +5,7 @@ Alert expressions provide a way to modify widget graphical properties such as co
 ## Example
 
 * Change bar color to `RED` if the threshold is exceeded.
-* If the threshold is within the normal range, but was violated at least once during the last hour, change the bar color to `YELLOW`.
+* If the threshold is within the normal range, but is violated at least once during the last hour, change the bar color to `YELLOW`.
 * Otherwise, apply `GREEN` as the color.
 
 ```ls

--- a/syntax/alert-expression.md
+++ b/syntax/alert-expression.md
@@ -8,7 +8,7 @@ Alert expressions provide a way to modify widget graphical properties such as co
 * If the threshold is within the normal range, but was violated at least once during the last hour, change the bar color to `YELLOW`.
 * Otherwise, apply `GREEN` as the color.
 
-```css
+```ls
 [widget]
   type = bar
   color = yellowgreen

--- a/syntax/control-structure.md
+++ b/syntax/control-structure.md
@@ -29,7 +29,7 @@ list servers = awsswgvml001, nurswgvml003
 
 `var` assigns an array, object, or function to a variable whose value and fields can be invoked with a placeholder.
 
-If the `var` assignment occupies one line, closing with  `endvar` is not required.
+If the `var` assignment occupies one line, closing with `endvar` is not required.
 
 ```ls
 var disks = [[9,2], [9,3], [8,0], [9,0], [9,1], [8,16]]
@@ -41,7 +41,7 @@ for di in disks
 endfor
 ```
 
-The list of entities can be loaded into a `var` array from the server using the [`getEntities`](./functions.md#getEntities) function.
+The list of entities can be loaded into a `var` array from the server using the [`getEntities`](./functions.md#getentities) function.
 
 ```ls
 var hosts = getEntities('svl-hosts')
@@ -117,11 +117,11 @@ for server in servers
   [widget] 
     type = box
     entity = @{server.name}
-    metric = network_sent_mb  
+    metric = network_sent_mb
     for net in server.networks
     [series]
       [tags]
-       interface = @{net}  
+       interface = @{net}
     endfor
 endfor
 ```
@@ -142,7 +142,7 @@ for server in servers
   for net in servers[server]
   [series]
     [tags]
-      interface = @{net}  
+      interface = @{net}
   endfor
 endfor
 ```
@@ -160,11 +160,11 @@ for server in servers
   [widget] 
     type = box
     entity = @{server[0]}
-    metric = network_sent_mb  
+    metric = network_sent_mb
     for net in server[1]
     [series]
       [tags]
-       interface = @{net}  
+       interface = @{net}
     endfor
 endfor
 ```

--- a/syntax/control-structure.md
+++ b/syntax/control-structure.md
@@ -88,12 +88,12 @@ endfor
  Order is arbitrary when using the [`Object.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) function.
 
 ```ls
-  var tags = {
-  'level': 'ERROR',
-  'command': 'com.axibase.tsd.Server',
-  'logger': 'com.axibase.tsd.web.DefaultExceptionHandler'
+var tags = {
+'level': 'ERROR',
+'command': 'com.axibase.tsd.Server',
+'logger': 'com.axibase.tsd.web.DefaultExceptionHandler'
 }
-  endvar
+endvar
 
 [widget]
   type = chart
@@ -114,7 +114,7 @@ var servers = [
 endvar
 
 for server in servers
-  [widget] 
+  [widget]
     type = box
     entity = @{server.name}
     metric = network_sent_mb
@@ -157,7 +157,7 @@ var servers = [
 endvar
 
 for server in servers
-  [widget] 
+  [widget]
     type = box
     entity = @{server[0]}
     metric = network_sent_mb

--- a/syntax/control-structure.md
+++ b/syntax/control-structure.md
@@ -6,7 +6,7 @@ The following control structures are supported: `list`, `var`, `for`, `if`.
 
 Assign a list of comma-separated elements, optionally located on multiple lines, to a named array an iterate through the array with a `for` loop.
 
-```css
+```ls
 list servers = awsswgvml001, nurswgvml003,
   nurswgvml006, nurswgvml007, nurswgvml009
 endlist
@@ -14,13 +14,13 @@ endlist
 
 If the elements fit on one line, `endlist` is not required.
 
-```css
+```ls
 list servers = awsswgvml001, nurswgvml003
 ```
 
 The `list` command is similar to `var`, without having to quote and enclose the elements in square brackets.
 
-```css
+```ls
 var servers = ['awsswgvml001', 'nurswgvml003']
 list servers = awsswgvml001, nurswgvml003
 ```
@@ -31,7 +31,7 @@ list servers = awsswgvml001, nurswgvml003
 
 If the `var` assignment occupies one line, closing with  `endvar` is not required.
 
-```css
+```ls
 var disks = [[9,2], [9,3], [8,0], [9,0], [9,1], [8,16]]
 for di in disks
     [series]
@@ -43,7 +43,7 @@ endfor
 
 The list of entities can be loaded into a `var` array from the server using the [`getEntities`](./functions.md#getEntities) function.
 
-```css
+```ls
 var hosts = getEntities('svl-hosts')
 for host in hosts
     [series]
@@ -62,7 +62,7 @@ Create the following visualization which tracks metric `cpu_idle` for entities `
 
 ### Iterating Over a List
 
-```css
+```ls
 list servers = nurswgvml010, nurswgvml007
   for server in servers
   [series]
@@ -74,7 +74,7 @@ endfor
 
 ### Iterating Over an Inline Array
 
-```css
+```ls
 for server in ['nurswgvml010', 'nurswgvml007']
   [series]
     entity = @{server}
@@ -87,7 +87,7 @@ endfor
 
  Order is arbitrary when using the [`Object.keys()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys) function.
 
-```css
+```ls
   var tags = {
   'level': 'ERROR',
   'command': 'com.axibase.tsd.Server',
@@ -106,7 +106,7 @@ endfor
 
 ### Iterating Over Objects with Named Fields
 
-```css
+```ls
 var servers = [
   {'name': 'nurswgvml001', 'networks': ['en3', 'en4']},
   {'name': 'nurswgvml002', 'networks': ['en5']}
@@ -128,7 +128,7 @@ endfor
 
 ### Iterating Over Object Properties
 
-```css
+```ls
 var servers = {
     'nurswgvml001': ['en3', 'en4'],
     'nurswgvml002': ['en5']
@@ -149,7 +149,7 @@ endfor
 
 ### Iterating Over a Multi-Dimensional Array
 
-```css
+```ls
 var servers = [
       ['nurswgvml001', ['en3', 'en4']],
       ['nurswgvml002', ['en5']]
@@ -173,7 +173,7 @@ Use `elementname_index` without control symbol `@` and brackets to access curren
 
 **Example**: Insert `[group]` line for each 4th element in the array.
 
-```css
+```ls
 for server in servers
   /* add [group] before every 4th element to display 4 widgets per row */
   if server_index % 4 == 0
@@ -187,7 +187,7 @@ endfor
 
 Similar layout with automated row breaks can be accomplished by specifying the `widgets-per-row` setting under `[group]` level.
 
-```css
+```ls
 [group]
   widgets-per-row = 4
 for server in servers
@@ -198,7 +198,7 @@ endfor
 
 Text inside placeholder `@{elementname}` is evaluated as an expression and can be used for concatenation and formatting.
 
-```css
+```ls
 list servers = 001, 003, 006, 007, 009
 for server in servers
   [series]
@@ -212,7 +212,7 @@ Evaluates an expression and prints settings if the expression is `true`. If the 
 
 Array elements are accessed in the `if` or `elseif` expression by name, not as a placeholder.
 
-```css
+```ls
 for server in servers
   [series]
     entity = @{server}
@@ -232,6 +232,6 @@ endfor
 
 To review the final configuration text after pre-processing, add `script = console.log(widgetConfig)` anywhere in the widget configuration and review the text on **Developer Console > Console** page.
 
-```css
+```ls
 script = console.log(widgetConfig)
 ```

--- a/syntax/extended-aggregators.md
+++ b/syntax/extended-aggregators.md
@@ -2,7 +2,7 @@
 
 ## `min_value_time`
 
-Computes the time when the minimum was reached for the first time in the period.
+Computes the time when the minimum is reached for the first time in the period.
 
 ```ls
 statistic = max_value_time
@@ -10,7 +10,7 @@ statistic = max_value_time
 
 ## `max_value_time`
 
-Computes the time when the maximum was reached for the first time in the period.
+Computes the time when the maximum is reached for the first time in the period.
 
 ```ls
 statistic = min_value_time

--- a/syntax/extended-aggregators.md
+++ b/syntax/extended-aggregators.md
@@ -4,7 +4,7 @@
 
 Computes the time when the minimum was reached for the first time in the period.
 
-```css
+```ls
 statistic = max_value_time
 ```
 
@@ -12,7 +12,7 @@ statistic = max_value_time
 
 Computes the time when the maximum was reached for the first time in the period.
 
-```css
+```ls
 statistic = min_value_time
 ```
 
@@ -26,7 +26,7 @@ statistic = min_value_time
 
 Computes the difference between the last and first value within the period. If there are multiple adjacent periods, computes delta as the difference between the last values of adjacent periods.
 
-```css
+```ls
 statistic = delta
 ```
 
@@ -34,7 +34,7 @@ statistic = delta
 
 Similar to delta except for special processing of resets. Applicable for incrementing non-negative metrics. Reset occurs when the series value is lower than the previous value, in which case the counter adds the difference between 0 and the current value.
 
-```css
+```ls
 statistic = counter
 ```
 

--- a/syntax/format-settings.md
+++ b/syntax/format-settings.md
@@ -2,7 +2,7 @@
 
 ## Supported Format Settings
 
-```css
+```ls
 format = bytes
 format = kilobytes
 format = megawatt
@@ -33,7 +33,7 @@ Perform rounding on displayed values:
 
 `round(value, number_of_digits)`
 
-```css
+```ls
 format = round(0)
 format = round(value/512, 1)
 format = round(-3)
@@ -57,7 +57,7 @@ Operation | Syntax
 
 Format values as a percentage of `100`.
 
-```css
+```ls
 format = percent
 ```
 
@@ -80,7 +80,7 @@ Control the number of displayed digits. Specify the exact number of digits in th
 
 ### Syntax
 
-```css
+```ls
 fixed(0, 3); // 0.000
 fixed(0); // 0
 fixed(1.2); // 1
@@ -112,7 +112,7 @@ Syntax | Description
 
 Format series values which represent millisecond duration using `intervalFormat` function or `interval-format` setting.
 
-```css
+```ls
 /* invoke intervalFormat function */
 format = intervalFormat('%dd %H:%M:%S')(value*1000)
 
@@ -177,7 +177,7 @@ Control the date format of the `x` axis for year, month, week, and day.
 
 #### Examples
 
-```css
+```ls
 day-format = %m/%d
 day-format = %y/%m/%d
 day-format = %Y/%m/%d
@@ -188,7 +188,7 @@ day-format = %Y %m/%d
 
 [![](./images/button.png)](https://apps.axibase.com/chartlab/d0bfcdf8)
 
-```css
+```ls
 day-format = %m %a
 day-format = %m/%aa
 day-format = %x
@@ -217,7 +217,7 @@ Use any combination of the following:
 
 #### Example
 
-```css
+```ls
 hour-format = %I %p
 hour-format = %H:%M
 ```

--- a/syntax/functions.md
+++ b/syntax/functions.md
@@ -40,7 +40,7 @@ The list contains built-in utility functions that can be included in Axibase Cha
 
 **Syntax**:
 
-```css
+```ls
 getTags(metric, tagName, [entity, [minInsertDate, [maxInsertDate, [url, [queryParameters]]]]])
 ```
 
@@ -77,7 +77,7 @@ Sends synchronous `GET` request to
 
 **Usage**:
 
-```css
+```ls
 var mount_points = getTags("disk_used", "mount_point", "nurswgvml006", "current_day")
 ```
 
@@ -99,7 +99,7 @@ var mount_points = getTags("disk_used", "mount_point", "nurswgvml006", "current_
 
 **Usage**:
 
-```css
+```ls
 var mount_points = getTags("disk_used", "mount_point", "nurswgvml007", null, null, null, {cache: true})
 ```
 
@@ -127,7 +127,7 @@ var mount_points = getTags("disk_used", "mount_point", "nurswgvml007", null, nul
 
 **Syntax**:
 
-```css
+```ls
 getSeries(metric, [entity, [minInsertDate, [maxInsertDate, [url, [queryParameters]]]]])
 ```
 
@@ -163,7 +163,7 @@ Sends synchronous `GET` requests to the
 
 **Usage**:
 
-```css
+```ls
 var seriesDescriptors = getSeries("disk_used", "nurswgvml007")
 ```
 
@@ -220,7 +220,7 @@ var seriesDescriptors = getSeries("disk_used", "nurswgvml007")
 
 **Syntax**:
 
-```css
+```ls
 getMetrics(entity, [expression, [tags, [url, [queryParameters]]]])
 ```
 
@@ -254,7 +254,7 @@ Sends synchronous `GET` requests to the
 
 **Usage**:
 
-```css
+```ls
 var metrics = getMetrics("nurswgvml007", "name LIKE '*cpu*user*'")
 ```
 
@@ -283,7 +283,7 @@ var metrics = getMetrics("nurswgvml007", "name LIKE '*cpu*user*'")
 
 **Syntax**:
 
-```css
+```ls
 getEntities(group, [expression, [tags, [url, [queryParameters]]]])
 ```
 
@@ -328,7 +328,7 @@ Sends synchronous `GET` requests to the
 
 **Usage**:
 
-```css
+```ls
 var entities = getEntities("docker-hosts", "name LIKE 'nur*'")
 ```
 
@@ -355,7 +355,7 @@ var entities = getEntities("docker-hosts", "name LIKE 'nur*'")
 
 **Syntax**:
 
-```css
+```ls
 range(start, end, [step], [format])
 ```
 
@@ -514,7 +514,7 @@ Limitations and features that are applied:
 
 **Syntax**:
 
-```css
+```ls
 csv name = header1, header2 ...
 cell11, cell12 ...
 cell21, cell22 ...
@@ -537,7 +537,7 @@ Use in the `preprocessor` stage.
 
 Using a table written in a CSV-like format: There are two columns, `name` (name of the country) and `value2006` (value in the year 2006). The return value is the difference between the current year value and the 2006 value. The following CSV is used:
 
-```css
+```ls
 csv countries =
   name, value2006
   Brazil, 13.2
@@ -594,7 +594,7 @@ This CSV is transformed into the following array:
 
 Iterate over the newly created array and set the value and entity based on thr retrieved country `name` and `value2006`.
 
-```css
+```ls
 for country in countries
     [series]
       replace-value = value - @{country.value2006}
@@ -623,7 +623,7 @@ Limitation and features that are applied to the text:
 
 **Syntax**:
 
-```css
+```ls
 csv csv_name from url
 ```
 
@@ -698,7 +698,7 @@ csv rows from https://raw.githubusercontent.com/axibase/atsd-use-cases/master/US
 
 Iterate over the created array and set the value and entity based on the retrieved country `name` and value or year `2006`.
 
-```css
+```ls
 for row in rows
   [series]
     replace-value = value - @{row[2006]}
@@ -717,7 +717,7 @@ for row in rows
 
 **Syntax**:
 
-```css
+```ls
 csv_name.values(column_name)
 ```
 
@@ -796,7 +796,7 @@ The CSV is transformed into the following array:
 
 Then retrieve values of the column `name`:
 
-```css
+```ls
 var names = countries.values('name')
 ```
 
@@ -808,7 +808,7 @@ Returned values are as follows:
 
 Iterate over each value and set the country tag.
 
-```css
+```ls
 for country_name in names
   [series]
   [tags]
@@ -827,7 +827,7 @@ endfor
 
 **Syntax**:
 
-```css
+```ls
 list_name.escape()
 ```
 
@@ -876,7 +876,7 @@ country = @{countries.escape()}
 
 **Usage**:
 
-```css
+```ls
 var countries = getTags('state.visa-refusal-rate', 'country', 'travel.state.gov')
 
 country = @{countries.escape()}
@@ -927,7 +927,7 @@ country = @{countries.values('name').escape()}
 
 **Syntax**:
 
-```css
+```ls
 previous(alias, [offset])
 ```
 
@@ -954,7 +954,7 @@ Use in `value-expression` settings.
 
 **Usage**:
 
-```css
+```ls
 value = previous('raw')
 ```
 
@@ -966,7 +966,7 @@ value = previous('raw')
 
 **Usage**:
 
-```css
+```ls
 value = previous('raw', 2)
 ```
 
@@ -978,7 +978,7 @@ value = previous('raw', 2)
 
 **Usage**:
 
-```css
+```ls
 value = 1 - previous('raw') / value('raw')
 ```
 
@@ -990,7 +990,7 @@ value = 1 - previous('raw') / value('raw')
 
 **Usage**:
 
-```css
+```ls
 value = 1 - previous('raw', 2) / value('raw')
 ```
 
@@ -1009,7 +1009,7 @@ value = 1 - previous('raw', 2) / value('raw')
 
 **Syntax**:
 
-```css
+```ls
 movavg(alias, count, [minCount])
 ```
 
@@ -1036,7 +1036,7 @@ Use in `value-expression` settings.
 
 **Usage**:
 
-```css
+```ls
 value = movavg('raw', 30)
 ```
 
@@ -1048,7 +1048,7 @@ value = movavg('raw', 30)
 
 **Usage**:
 
-```css
+```ls
 value = movavg('raw', 30, 0)
 ```
 
@@ -1068,7 +1068,7 @@ value = movavg('raw', 30, 0)
 
 **Syntax**:
 
-```css
+```ls
 meta(alias)
 ```
 
@@ -1094,7 +1094,7 @@ Use in `value-expression` settings.
 
 **Usage**:
 
-```css
+```ls
 value = value('raw') / meta('raw').metric.maxValue
 ```
 
@@ -1114,7 +1114,7 @@ value = value('raw') / meta('raw').metric.maxValue
 
 **Syntax**:
 
-```css
+```ls
 entityTag(alias, tagName)
 ```
 
@@ -1140,7 +1140,7 @@ Use in `value-expression` settings.
 
 **Usage**:
 
-```css
+```ls
 size = entityTag('cpu_count')
 ```
 
@@ -1160,7 +1160,7 @@ size = entityTag('cpu_count')
 
 **Syntax**:
 
-```css
+```ls
 metricTag(alias, tagName)
 ```
 
@@ -1187,7 +1187,7 @@ Use in `value-expression` settings.
 
 **Usage**:
 
-```css
+```ls
 value = metricTag('raw', 'threshold_value')
 alert-expression = value() > metricTag('threshold_value')
 ```
@@ -1210,7 +1210,7 @@ alert-expression = value() > metricTag('threshold_value')
 
 **Syntax**:
 
-```css
+```ls
 requestMetricsSeriesValues([fieldPath, [callback, [metric, [unique, [queryParameters]]]]])
 ```
 
@@ -1243,7 +1243,7 @@ Sends asynchronous `GET` requests to
 
 The `fieldPath` `"tags.mount_point"` reads `tags`in each descriptor then retrieves the `mount_point` field.
 
-```css
+```ls
 [dropdown]
   options = javascript: requestMetricsSeriesValues("tags.mount_point")
   change-field = series.tags.mount_point
@@ -1265,7 +1265,7 @@ The `fieldPath` `"tags.mount_point"` reads `tags`in each descriptor then retriev
 
 **Syntax**:
 
-```css
+```ls
 requestEntitiesMetricsValues([fieldPath, [callback, [entity, [unique, [queryParameters]]]]])
 ```
 
@@ -1297,7 +1297,7 @@ Sends asynchronous `GET` requests to
 
 To populate the drop-down list with names of metrics collected for the entity use the following syntax:
 
-```css
+```ls
 [dropdown]
   options = javascript: requestEntitiesMetricsValues("name")
   change-field = series.metric
@@ -1321,7 +1321,7 @@ The content of the drop-down list is shown below:
 
 **Syntax**:
 
-```css
+```ls
 requestPropertiesValues([valueFieldPath, [textFieldPath, [callback, [entity, [propertyType, [unique, [postBody]]]]]]])
 ```
 
@@ -1354,7 +1354,7 @@ Sends asynchronous `POST` requests to
 
 To populate the drop-down list with the IDs of `network` properties use the following syntax:
 
-```css
+```ls
 [dropdown]
   options = javascript: requestPropertiesValues("key.id", null, null, "network")
   change-field = property.keys.id
@@ -1375,7 +1375,7 @@ Below is the content of the drop-down list:
 
 To populate the drop-down list with the names of entities for which the metric is collected use the following syntax.
 
-```css
+```ls
 [dropdown]
   options = javascript: requestMetricsSeriesValues("entity")
   change-field = series.entity
@@ -1387,7 +1387,7 @@ Below is the content of the drop-down list:
 
 To populate the drop-down list with values of the `mount_point` tag use the following syntax. The `fieldPath` `"tags.mount_point"` reads `tags`in each descriptor then retrieves the `mount_point` field.
 
-```css
+```ls
 [dropdown]
   options = javascript: requestMetricsSeriesValues("tags.mount_point")
   change-field = series.tags.mount_point
@@ -1410,7 +1410,7 @@ To fill the drop-down list with values of `mount_point` tag of the series, whose
 
 > Note that the series can be filtered by entity using the expression `queryParameter`.
 
-```css
+```ls
 [dropdown]
   change-field = series.tags.mount_point
 
@@ -1435,7 +1435,7 @@ To fill the drop-down list with entity tag values it is necessary to make two re
 * Get entity names from series descriptors.
 * Request entity tags for that entities.
 
-```css
+```ls
 [dropdown]
    change-field = series.entity
 
@@ -1466,7 +1466,7 @@ Below is the content of the drop-down list:
 
 **Syntax**:
 
-```css
+```ls
 requestMetricsSeriesValues([fieldPath, [callback, [metric, [unique, [queryParameters]]]]])
 ```
 
@@ -1500,7 +1500,7 @@ Sends asynchronous `GET` request to
 
 To fill the drop-down list with options with the value of the `iucr` tag and the text from the `description` tag, use the following syntax:
 
-```css
+```ls
 [dropdown]
   options = javascript: requestMetricsSeriesOptions("tags.iucr", "tags.description")
   change-field = series.tags.iucr
@@ -1525,7 +1525,7 @@ Below is the content of the drop-down list:
 
 **Syntax**:
 
-```css
+```ls
 requestEntitiesMetricsValues([fieldPath, [callback, [entity, [unique, [queryParameters]]]]])
 ```
 
@@ -1559,7 +1559,7 @@ Sends asynchronous `GET` request to
 
 To fill the drop-down list with options defined by the value of `iucr` tag and text from the `description` tag, use the following syntax:
 
-```css
+```ls
 [dropdown]
   options = javascript: requestEntitiesMetricsOptions("name", "tags.description", null, null, null,{tags:"*",limit:15})
   change-field = metric
@@ -1586,7 +1586,7 @@ Below is the content of the drop-down list:
 
 **Syntax**:
 
-```css
+```ls
 requestPropertiesOptions([valueFieldPath, [textFieldPath, [callback, [entity, [propertyType, [unique, [postBody]]]]]]])
 ```
 
@@ -1621,7 +1621,7 @@ Sends asynchronous `POST` request to
 
 To fill drop-down list with values from `entity` and text from tag `app`, use the following syntax:
 
-```css
+```ls
 [dropdown]
   options = javascript: requestPropertiesOptions("entity", "tags.app", null, ["nurswgvml006","nurswgvml007", "nurswgvml010", "nurswgvml301", "nurswgvml502"], "$entity_tags")
   change-field = entity
@@ -1643,7 +1643,7 @@ The content of the drop-down list is shown here:
 
 To fill a drop-down list with options in which values are retrieved from the `name` field of the metric descriptor and text from the tag `description`, `textFieldPath` as string can be used.
 
-```css
+```ls
 [dropdown]
   options = javascript: requestEntitiesMetricsOptions('name', 'tags.description', null, null, null, {tags:'*',limit:15})
   change-field = metric
@@ -1655,7 +1655,7 @@ Below is the content of the drop-down list:
 
 Fill the drop-down list with values retrieved from the `name` field of the metric descriptor and the text from the tag `description` or tag `documentation`, if the descriptor has no value for the tag `description`, `textFieldPath` as an array can be used
 
-```css
+```ls
 [dropdown]
   options = javascript: requestEntitiesMetricsOptions('name', ['tags.description','tags.documentation'], null, null, null, {tags:'*',limit:15})
   change-field = metric
@@ -1673,7 +1673,7 @@ Below is the content of the drop-down list:
   * If `callback` is specified, `valueFieldPath` and `textFieldPath` are ignored.
 * Function returns an array of objects, representing options.
 
-```css
+```ls
 [
 ...
 {
@@ -1688,7 +1688,7 @@ Below is the content of the drop-down list:
 
 To populate the drop-down list with the names of metrics, collected for the entity, and texts which are changed values of the `description` tag, use the following syntax:
 
-```css
+```ls
 [dropdown]
   change-field = metric
 

--- a/syntax/label-formatting.md
+++ b/syntax/label-formatting.md
@@ -61,7 +61,7 @@ label-format = javascript:keepAfterLast(tags.logger, '.')
 
 [![](./images/button.png)](https://apps.axibase.com/chartlab/675c5467)
 
-Functions may be nested to apply multiple format settings.
+Use nested functions to apply multiple format settings.
 
 ```ls
 label-format = javascript:capitalize(replace(metric, '_', ' '))
@@ -114,14 +114,14 @@ label-format = entity
 ### `tags.tagName`
 
 ```ls
-  label-format = tags.mount_point
-  /* Displays labels from tag mount_point in the legend */
-  [series]
-    entity = nurswgvml006
-    metric = disk_used_percent
-    [tags]
-      mount_point = *
-      file_system = *  
+label-format = tags.mount_point
+/* Displays labels from tag mount_point in the legend */
+[series]
+  entity = nurswgvml006
+  metric = disk_used_percent
+  [tags]
+    mount_point = *
+    file_system = *  
 ```
 
 ![](./images/label-formatting2.png)

--- a/syntax/label-formatting.md
+++ b/syntax/label-formatting.md
@@ -4,7 +4,7 @@ Use the `label-format` setting to customize series labels displayed in the widge
 
 The default `label-format` pattern is:
 
-```css
+```ls
 entity: metric: tags: statistics: period: dataType - forecastName: rate
 ```
 
@@ -25,7 +25,7 @@ Supported keywords in the `label-format` pattern are:
 
 Create a new label format configuration using a combination of the supported keywords.
 
-```css
+```ls
 label-format = statistics : metric
 ```
 
@@ -49,7 +49,7 @@ Invoke built-in string functions to format series fields.
 | `removeBeginning` | Removes the given substring from the beginning of the string.|
 | `removeEnding`| Removes the given substring from the end of the string.  |
 
-```css
+```ls
 label-format = javascript:keepAfterLast(tags.logger, '.')
 #returns AuthenticationFilter
 [series]
@@ -63,7 +63,7 @@ label-format = javascript:keepAfterLast(tags.logger, '.')
 
 Functions may be nested to apply multiple format settings.
 
-```css
+```ls
 label-format = javascript:capitalize(replace(metric, '_', ' '))
 /* replace underscores with whitespace and capitalize all words */
 [series]
@@ -81,7 +81,7 @@ Use the `label-format` setting to replace `entity` and `metric` names with label
 
 Include the `addMeta = true` expression on the `[configuration]` level.
 
-```css
+```ls
 [configuration]
 add-meta = true
 /* Format label using metadata identifiers */
@@ -96,7 +96,7 @@ label-format = javascript: (meta.entity.label ? meta.entity.label : entity) + ":
 
 ### `entity`
 
-```css
+```ls
 label-format = entity
 /* Display only the entity name in the legend */
 [series]
@@ -113,7 +113,7 @@ label-format = entity
 
 ### `tags.tagName`
 
-```css
+```ls
   label-format = tags.mount_point
   /* Displays labels from tag mount_point in the legend */
   [series]
@@ -130,7 +130,7 @@ label-format = entity
 
 ### `entity : tagValue`
 
-```css
+```ls
 label-format = entity: tagValue
 /* Displays labels from entity followed by tagValue in the legend */
 [tags]

--- a/syntax/linking.md
+++ b/syntax/linking.md
@@ -6,7 +6,7 @@ The `on-series-click` setting links widgets displayed on the same portal for int
 
 Trigger multiple `on-series-click` actions to update multiple widgets simultaneously.
 
-```css
+```ls
 on-series-click = var seriesConfig = $.extend({}, c.config.originalConfig.series[0], {entity: series.entity, tags: series.tags});
 ```
 
@@ -16,7 +16,7 @@ on-series-click = var seriesConfig = $.extend({}, c.config.originalConfig.series
 
 The `on-series-click` setting does not affect behavior of the widget on the header click handler. The syntax below demonstrates how to update headers when using linking features.
 
-```css
+```ls
 /* update console */
 on-series-click = consoleWidget.post = $.extend(true, {}, consoleWidget.post, { queries: [$.extend(interval, { entities: [series.entity], tags: series.tags })] }); consoleWidget.reload(); 
 

--- a/syntax/linking.md
+++ b/syntax/linking.md
@@ -18,7 +18,7 @@ The `on-series-click` setting does not affect behavior of the widget on the head
 
 ```ls
 /* update console */
-on-series-click = consoleWidget.post = $.extend(true, {}, consoleWidget.post, { queries: [$.extend(interval, { entities: [series.entity], tags: series.tags })] }); consoleWidget.reload(); 
+on-series-click = consoleWidget.post = $.extend(true, {}, consoleWidget.post, { queries: [$.extend(interval, { entities: [series.entity], tags: series.tags })] }); consoleWidget.reload();
 
 /* change headers */
 on-series-click = $('.detailWidget').find('.widgetTitle').tex (keepAfterLast(series.tags.command, '.') + ': ' + series.entity)  

--- a/syntax/selecting-series.md
+++ b/syntax/selecting-series.md
@@ -4,7 +4,7 @@
 
 Configuration syntax provides a way to load and display data for time series stored in ATSD. Series values change over time and data history is visualized with different types of graphs.
 
-```css
+```ls
 /* Widget level settings affect all series. */
 [widget]
   type = chart
@@ -37,7 +37,7 @@ Review any series in the database on the **Metrics > `metric_name` > Series** pa
 
 Create drop-down lists using `tag-dropdowns` syntax:
 
-```css
+```ls
 [widget]
 tags-dropdowns = true
 label-format = tags
@@ -51,7 +51,7 @@ label-format = tags
 
 To display values for a specific series, specify the composite key in the `[series]` section of the widget configuration:
 
-```css
+```ls
 /* Series without tags */
 metric = cpu_busy
 entity = nurswgvml007
@@ -74,7 +74,7 @@ By default, the database returns all series matching a request, including series
 
 This enables loading series using only a subset of tags that are still sufficient to uniquely identify a series:
 
-```css
+```ls
 /* Series with tags */
 [series]
 metric = df.bytes.percentused
@@ -87,7 +87,7 @@ This configuration matches all series with `mount = /` key-value pair, including
 
 To disable partial tag match, use the `exact-match = true` setting:
 
-```css
+```ls
 /* Series with tags */
 metric = df.bytes.percentused
 entity = nurswgvml006
@@ -100,7 +100,7 @@ When partial match is disabled, the database returns series with exactly the sam
 
 While making the configuration more compact, partial match can produce undetermined results if the partial key matches multiple series where only one series is expected:
 
-```css
+```ls
 /* Series with Tags */
 [series]
 metric = df.bytes.percentused
@@ -119,7 +119,7 @@ The resulting series is merged from 3 underlying different series and provides a
 
 To control how multiple matched series are processed, use the `multiple-series = true | false` setting.
 
-```css
+```ls
 /* Display all series with tag fstype=ext4 without merging */
 multiple-series = true
 [series]
@@ -129,7 +129,7 @@ multiple-series = true
 
 Use the `multiple-series` setting to display all series without specifying any tags in widget configuration:
 
-```css
+```ls
 /* Display all series without merging */
 multiple-series = true
 [series]
@@ -143,7 +143,7 @@ The default value of the `multiple-series` setting is `true` in the following ca
 * Tag value contains [wildcard](./wildcards.md): `mount = /t*`
 * `entity-expression`, `entity-group`, or `tag-expression` settings are present.
 
-```css
+```ls
 /* Select series using tag value wildcards. `multiple-series` is TRUE */
   [tags]
     fstype = ext4  
@@ -192,7 +192,7 @@ Examples:
 
 Widget syntax provides a number of options to select series for multiple entities with the same metric:
 
-```css
+```ls
 /* Select specific entity by name */
 entity = nurswgvml006
 
@@ -217,7 +217,7 @@ entity-group = nur-collectors
 
 > Refer to [Data API Documentation](https://axibase.com/docs/atsd/api/data/series/query.html#entity-filter) for additional information about these settings.
 
-```css
+```ls
 /* Retrieve series for entities starting with nurswgvml00 */
 [series]
   entity = nurswgvml00*
@@ -236,7 +236,7 @@ As an alternative to specifying series settings manually and using [wildcards](.
 
 `getTags()`:
 
-```css
+```ls
 var tags = getTags('df.bytes.percentused', 'mount','nurswgvml006')
 
 for tagValue in tags
@@ -248,7 +248,7 @@ endfor
 
 `getSeries()`
 
-```css
+```ls
 var seriesList = getSeries('df.bytes.percentused','nurswgvml006')
 
 for sobj in seriesList
@@ -268,7 +268,7 @@ endfor
 
 The `series-limit = int` setting can limit the number of possible series returned by the database for wildcard queries. Since the limit is applied to an unsorted list of matched series, the results vary between requests, making the setting useful for exploring a dataset to prevent the widgets from loading excessive series into browser memory.
 
-```css
+```ls
 entity = *
 series-limit = 10
 [series]
@@ -278,7 +278,7 @@ series-limit = 10
 
 For more flexible visibility control on the client, use the display and enabled settings.
 
-```css
+```ls
 entity = *
 display = value == top(1) || value == bottom(1)
 [series]

--- a/syntax/thresholds.md
+++ b/syntax/thresholds.md
@@ -8,7 +8,7 @@ Specify lower or upper thresholds or combine the two to trigger a violation when
 
 Series violates the threshold when its value exceeds the maximum threshold.
 
-```css
+```ls
 [series]
   max-threshold = 60
   alert-expression = value > 60
@@ -23,7 +23,7 @@ Series violates the threshold when its value exceeds the maximum threshold.
 
 Series violates the threshold when its value is below the minimum threshold.
 
-```css
+```ls
 [series]
   min-threshold = 7
   alert-expression = value > 7
@@ -38,7 +38,7 @@ Series violates the threshold when its value is below the minimum threshold.
 
 Percentage of time within the period when the series values did not exceed the threshold. Computed as sum of violation intervals divided by the period duration.
 
-```css
+```ls
 [series]
   statistic = threshold_percent
   max-threshold = 10
@@ -55,7 +55,7 @@ Percentage of time within the period when the series values did not exceed the t
 
 Number of sequences within the period when the series values exceeded the threshold. Consecutive observations violating the threshold are treated as one sequence.
 
-```css
+```ls
 [series]
   statistic = threshold_count
   max-threshold = 40
@@ -72,7 +72,7 @@ Number of sequences within the period when the series values exceeded the thresh
 
 Total duration of intervals within the period when the series values exceeded the threshold. Note, when using `threshold_duration` with an `alert-expression` the `value` argument is measured in **milliseconds**.
 
-```css
+```ls
 [series]
   statistic = threshold_duration
   min-threshold = 10

--- a/syntax/thresholds.md
+++ b/syntax/thresholds.md
@@ -36,7 +36,7 @@ Series violates the threshold when its value is below the minimum threshold.
 
 ## `threshold_percent`
 
-Percentage of time within the period when the series values did not exceed the threshold. Computed as sum of violation intervals divided by the period duration.
+Percentage of time within the period when the series values does not exceed the threshold. Computed as sum of violation intervals divided by the period duration.
 
 ```ls
 [series]

--- a/syntax/value_functions.md
+++ b/syntax/value_functions.md
@@ -6,7 +6,7 @@ This document describes functions, which can be referenced in the `value` settin
 
 The `value` setting is specified by the `series` section.
 
-```css
+```ls
 # Define the original series, which values used in creating a derived (computed) series.
 # The original series must exist in the database
 [series]

--- a/syntax/wildcards.md
+++ b/syntax/wildcards.md
@@ -4,7 +4,7 @@ Use wildcards in tag values to retrieve multiple series from the server instead 
 
 Specify the `*` wildcard as either `tag` value or `entity` name.
 
-```css
+```ls
 [series]
   entity = nurswgvml007
   metric = disk_used_percent

--- a/widgets/calendar-chart/README.md
+++ b/widgets/calendar-chart/README.md
@@ -35,7 +35,7 @@ Thresholds | `thresholds = 0, 25, 50, 75, 100` | Define threshold value.<br>Defa
 
 ### Custom Colors
 
-```css
+```ls
 colors = green, yellow, red
 thresholds = 0, 50, 75, 100
 ```
@@ -46,7 +46,7 @@ thresholds = 0, 50, 75, 100
 
 ### Left Legend
 
-```css
+```ls
 legend-position = left
 ```
 
@@ -62,7 +62,7 @@ legend-position = left
 
 ### Threshold
 
-```css
+```ls
 thresholds = 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 ```
 

--- a/widgets/graph/README.md
+++ b/widgets/graph/README.md
@@ -118,7 +118,7 @@ Link series to edges or vertices by indicating the `alias` in the series paramet
 
 ### Example Configuration
 
-```css
+```ls
 [widget]
 height-units = 4
 width-units = 4
@@ -179,7 +179,7 @@ value = channel1
 
 Activate hierarchial mode using the `mode` setting:
 
-```css
+```ls
 mode = hierarchial
 ```
 
@@ -187,7 +187,7 @@ mode = hierarchial
 
 In the event of an alert-expression response on the time series of the vertex or edge to which the time series is tied. Value of alert-style can be either string or script. If alert-style is script, the variable alert is available, and it is equal to the value that the alert returns. The following styles are applied (in a specified order) in the parameters below:
 
-```css
+```ls
 /* widget level settings */
 [widget]
 alert-style = color: red
@@ -211,7 +211,7 @@ node-alert-style = color: red
 
 ### Example Syntax
 
-```css
+```ls
 /* Modify stroke width of series line on alert */
 link-alert-style = if (alert > 99) return 'stroke-width:3px';
 
@@ -221,7 +221,7 @@ node-alert-style = if (alert > 99) return 'fill:red';
 
 ### Configuration Example
 
-```css
+```ls
 [widget]
 type = graph
 title = Channel_Graph
@@ -308,7 +308,7 @@ Color and width parameters are applied to the edge and vertices based on `link-w
 
 `alert-expression` styles are superimposed over the threshold styles.
 
-```css
+```ls
 [widget]
 mode = hierarchy
 type = graph

--- a/widgets/histogram/README.md
+++ b/widgets/histogram/README.md
@@ -33,7 +33,7 @@ Settings inherited from [Shared Widget `[series]` Syntax](../shared/README.md): 
 
 #### Filter series based on a time lag
 
-```css
+```ls
 display = this.lastRequestTime - this.last.t < 60*200
 ```
 
@@ -43,7 +43,7 @@ display = this.lastRequestTime - this.last.t < 60*200
 
 #### Sort top two series by value
 
-```css
+```ls
 display = value >= top(2)
 ```
 
@@ -53,7 +53,7 @@ display = value >= top(2)
 
 #### Filter series with value greater than `10`
 
-```css
+```ls
 display = value < 10
 ```
 
@@ -65,7 +65,7 @@ display = value < 10
 
 #### Stacked Histogram
 
-```css
+```ls
 mode = stack
 ```
 
@@ -75,7 +75,7 @@ mode = stack
 
 #### Multiple Series
 
-```css
+```ls
 [series]
     entity = nurswgvml006
     metric = cpu_busy

--- a/widgets/pie-chart/README.md
+++ b/widgets/pie-chart/README.md
@@ -66,7 +66,7 @@ Setting|Syntax|Description|Example
 
 ### Configuration
 
-```css
+```ls
 [widget]
   type = pie
   timespan = 15 minute
@@ -91,7 +91,7 @@ Setting|Syntax|Description|Example
 
 ### Ring Icons
 
-```css
+```ls
 [widget]
   type = pie
   mode = ring
@@ -107,7 +107,7 @@ Setting|Syntax|Description|Example
 
 ### Series Labels
 
-```css
+```ls
 [widget]
   series-labels = value >= 2000000 ? 'connected' : 'auto'
 ```
@@ -118,7 +118,7 @@ Setting|Syntax|Description|Example
 
 ### Pie
 
-```css
+```ls
 [widget]
   type = pie
 ```
@@ -129,7 +129,7 @@ Setting|Syntax|Description|Example
 
 ### Ring
 
-```css
+```ls
 [widget]
   type = pie
   mode = ring
@@ -141,7 +141,7 @@ Setting|Syntax|Description|Example
 
 ### Alert
 
-```css
+```ls
 [widget]
   alert-expression = value < 3*1024*1024
   alert-style = fill: red
@@ -153,7 +153,7 @@ Setting|Syntax|Description|Example
 
 ### Total and Other
 
-```css
+```ls
 [widget]
   total-value = 1048576
 
@@ -167,7 +167,7 @@ Setting|Syntax|Description|Example
 
 ### Hidden Other Segment
 
-```css
+```ls
 [widget]
 total-value = 1048576
 ```

--- a/widgets/shared/README.md
+++ b/widgets/shared/README.md
@@ -115,7 +115,7 @@ Refresh Error Interval | `error-refresh-interval = 30 minute`| Define the wait p
 
 `[tags]` syntax examples:
 
-```css
+```ls
 [tags]
   mount_point = /tmp
   fstype = tmpfs
@@ -123,14 +123,14 @@ Refresh Error Interval | `error-refresh-interval = 30 minute`| Define the wait p
 
 If there are several values for the same tag, separate the values with a comma:
 
-```css
+```ls
 [tags]
   tag_name = tag_value1, tag_value2
 ```
 
 If the tag name contains an equals sign `=` or the tag value contains a comma`,`, escape them with a backslash `\`:
 
-```css
+```ls
 [tags]
   tag\=name = tag\,value
 ```
@@ -139,14 +139,14 @@ The tag name and value are `tag=name` and `tag=value`, respectively.
 
 If the tag name contains reserved names such as setting names, surround the tag name with quotes to avoid collisions:
 
-```css
+```ls
 [tags]
   "type" = sensor
 ```
 
 ### `[series]` Example
 
-```css
+```ls
 [series]
   entity    entity == nurswgvml006
   metric  nurswgvml006    = disk_used_percent

--- a/widgets/streaming-table/README.md
+++ b/widgets/streaming-table/README.md
@@ -27,7 +27,7 @@ Under `[series]` level settings for Streaming Table widget, specify `hide-if-emp
 
 ### Configuration
 
-```css
+```ls
 [widget]
   type = table
   title = CPU Usage
@@ -61,7 +61,7 @@ Under `[series]` level settings for Streaming Table widget, specify `hide-if-emp
 
 ### `min` and `max` Value Time
 
-```css
+```ls
 [widget]
 alert-expression = this.alert = value <= min && value < avg ? 1 : value >= max && value > avg ? 2 : 0
   [column]
@@ -77,7 +77,7 @@ alert-expression = this.alert = value <= min && value < avg ? 1 : value >= max &
 
 ### Sliding Window
 
-```css
+```ls
 /*
 This example visualizes relative changes for
 many metrics at once, highlighting which metrics
@@ -95,7 +95,7 @@ metrics that reached minimum are highlighted with green.
 
 ### Color Grid
 
-```css
+```ls
 [column]
   key = s-6
   label = Query-6
@@ -110,7 +110,7 @@ metrics that reached minimum are highlighted with green.
 
 ### Alert
 
-```css
+```ls
 [widget]
   alert-expression = value > 4
   alert-style = background-color: orange
@@ -124,7 +124,7 @@ metrics that reached minimum are highlighted with green.
 
 <!-- markdownlint-disable MD104 -->
 
-```css
+```ls
 [configuration]
 entity = 10.102.0.15
 metric = dbqueuemonitor
@@ -145,7 +145,7 @@ endlist
 
 ### Multiple Metrics
 
-```css
+```ls
 [series]
   entity = nurswgvml009
   metric = cpu_busy
@@ -165,7 +165,7 @@ endlist
 
 ### Multiple Tags
 
-```css
+```ls
 [column]
   tag = mount_point
   label = Mount Point
@@ -181,7 +181,7 @@ endlist
 
 ### Configure Columns
 
-```css
+```ls
 script
   cmdb = {
    "nurswgvml006": {"location": "Cupertino", "type": "prod"},

--- a/widgets/time-chart/README.md
+++ b/widgets/time-chart/README.md
@@ -77,13 +77,13 @@ Series Type | `series-type = s3` | Use this setting in `stack` mode as a groupin
 
 Hide empty series:
 
-```css
+```ls
 display = !isNaN(value)
 ```
 
 Hide series without data in the previous 60 minutes:
 
-```css
+```ls
 display = this.lastRequestTime - this.last.t. < 60 * 60000
 ```
 
@@ -132,13 +132,13 @@ To remove selection intervals and aggregation periods, drag and drop the interva
 
 Modify time chart widget controls with the `defaultChartConfig.script` setting at the `[configuration]` level.
 
-```css
+```ls
 defaultChartConfig.script = widget.chart.panels[1].expand(8)
 ```
 
 Substitute `8` with the desired amount of control to be displayed.
 
-```css
+```ls
 defaultChartConfig.script = widget.chart.panels[1].expand(6)
 ```
 
@@ -148,7 +148,7 @@ defaultChartConfig.script = widget.chart.panels[1].expand(6)
 
 To create specific groups of controls use long-form syntax:
 
-```css
+```ls
 defaultChartConfig.script = widget.panels.type.data(['detail', 'avg', 'max', 'min', 'percentile 50', 'percentile 99', 'percentile 95', 'percentile 90', 'percentile 75', 'sum', 'count', '+'])
 ```
 
@@ -175,7 +175,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Offset
 
-```css
+```ls
 [series]
   label = yesterday
   time-offset = 1 day
@@ -190,7 +190,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Dual Axis
 
-```css
+```ls
 [series]
   entity = nurswgvml007
   metric = memfree
@@ -203,7 +203,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Stack
 
-```css
+```ls
 [widget]
   type = chart
   mode = stack
@@ -215,7 +215,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Stack Average
 
-```css
+```ls
 [widget]
   type = chart
   mode = stack
@@ -228,7 +228,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Area
 
-```css
+```ls
 [widget]
   type = chart
   stack = true
@@ -244,7 +244,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Column
 
-```css
+```ls
 [widget]
   type = chart
   mode = column
@@ -256,7 +256,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Column Stack
 
-```css
+```ls
 [widget]
   type = chart
   mode = column-stack
@@ -268,7 +268,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Column Alert
 
-```css
+```ls
 [series]
   alert-expression = value > 75
   alert-style = fill: orange; stroke: orange
@@ -280,7 +280,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Percentile
 
-```css
+```ls
 [series]
   entity = nurswgvml010
   metric = cpu_busy
@@ -293,7 +293,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Forecast
 
-```css
+```ls
 [series]
   entity = nurswgvml007
   metric = cpu_busy
@@ -306,7 +306,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Disconnect
 
-```css
+```ls
 [widget]
   disconnect-interval = 1 minute
   disconnect-value = 0
@@ -318,7 +318,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Threshold
 
-```css
+```ls
 [threshold]
   color = red
   value = 75
@@ -331,7 +331,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Alert
 
-```css
+```ls
 [widget]
   alert-expression = value > 75
   alert-style = stroke: red; stroke-width: 3
@@ -343,7 +343,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Violations
 
-```css
+```ls
 [series]
   value = var v = value('s7');
   value = if (v > 50) return v;
@@ -356,7 +356,7 @@ Add or remove each control component to show or hide it from the widgets:
 
 ### Violations Average
 
-```css
+```ls
 [series]
   entity = nurswgvml006
   metric = nmon.cpu_total.busy%
@@ -381,7 +381,7 @@ Insert messages into the database as series, using series tags to encode message
 series e:e-highlight d:2016-07-21T15:05:00Z m:m-highlight=75 t:msg="Traffic Stopped"
 ```
 
-```css
+```ls
 [series]
   entity = e-highlight
   metric = m-highlight
@@ -395,7 +395,7 @@ series e:e-highlight d:2016-07-21T15:05:00Z m:m-highlight=75 t:msg="Traffic Stop
 
 Overlay multiple intervals on the time (`x`) axis with elapsed time (interval) formatting.
 
-```css
+```ls
 [widget]
   interval-format = true
 ```

--- a/widgets/treemap/README.md
+++ b/widgets/treemap/README.md
@@ -50,7 +50,7 @@ For `[other]` and `[series]` tags in Treemap widget, define `[properties]` level
 
 This setting displays a table in the tooltip that appears upon series rectangle mouseover.
 
-```css
+```ls
 /* Define upper series tooltip */
 [properties]
   Data Center = Cuperito
@@ -72,7 +72,7 @@ This setting displays a table in the tooltip that appears upon series rectangle 
 
 ### Manual Thresholds and Size
 
-```css
+```ls
 width-units = 1
 height-units = 1
 thresholds = 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
@@ -90,7 +90,7 @@ thresholds = 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100
 
 ### Manual Thresholds
 
-```css
+```ls
 thresholds = 0, 25, 50, 75, 100
 ```
 


### PR DESCRIPTION
* Corrects `css` dialect to `ls` for charts repository.

* I did the same for non-merged PRs as well so the whole repo should be in compliance at this point.